### PR TITLE
retrofit string interps for python 2.7 support, add prereq to readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,6 @@
 # SteamPlayLookup
 Simple Python Script to Automagically Lookup GameID's
+
+## Prerequisite
+
+`pip install requests`

--- a/generateSteamIDs.py
+++ b/generateSteamIDs.py
@@ -21,8 +21,7 @@ class SteamPlayLookup:
         print("Now outputting to your file...")
         OutputFile = open(PathList[1], 'w')
         for ID in OutputList: # Write each AppID to the output text-file.
-            OutputFile.write('{}'.format(ID))
-            OutputFile.write("\n")
+            OutputFile.write('{}\n'.format(ID))
 
         print("Finished.")
 
@@ -35,7 +34,7 @@ class SteamPlayLookup:
                 if app['name'].lower().strip() == game.lower().strip(): # Clean whitespace, case-insensitive etc.
                     currentAppID = app['appid'] # If game is found in API, get the appid.
                     break
-            print("{currentAppID} - {game}".format(currentAppID=currentAppID,game=game))
+            print("{currentAppID} - {game}".format(currentAppID, game))
             OutputList.append(currentAppID)
 
         return OutputList

--- a/generateSteamIDs.py
+++ b/generateSteamIDs.py
@@ -21,9 +21,10 @@ class SteamPlayLookup:
         print("Now outputting to your file...")
         OutputFile = open(PathList[1], 'w')
         for ID in OutputList: # Write each AppID to the output text-file.
-            OutputFile.write(f"{ID}\n")
+            OutputFile.write('{}'.format(ID))
+            OutputFile.write("\n")
 
-        print(f"Finished.")
+        print("Finished.")
 
     # Function to lookup a game's title within the JSON blob from Steam's API.
     def lookup(self, lookup_list, api_json):
@@ -34,7 +35,7 @@ class SteamPlayLookup:
                 if app['name'].lower().strip() == game.lower().strip(): # Clean whitespace, case-insensitive etc.
                     currentAppID = app['appid'] # If game is found in API, get the appid.
                     break
-            print(f"{currentAppID} - {game}")
+            print("{currentAppID} - {game}".format(currentAppID=currentAppID,game=game))
             OutputList.append(currentAppID)
 
         return OutputList


### PR DESCRIPTION
certainly less elegant, but works on 2.7 where my current instance is pinned down on